### PR TITLE
Add benchmarks for hash/maphash and github.com/dolthub/maphash

### DIFF
--- a/bench/go.mod
+++ b/bench/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/coocood/freecache v1.2.3
 	github.com/dgraph-io/ristretto v0.1.1
+	github.com/dolthub/maphash v0.1.0
 	github.com/elastic/go-freelru v0.8.0
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/zeebo/xxh3 v1.0.2

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -13,6 +13,8 @@ github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWa
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elastic/go-freelru v0.8.0 h1:T4N1cAnrMIHvN3UmZ15wKT/yaVi9C9FgHeJqLoy+1lc=
@@ -28,13 +30,13 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/bench/hash_test.go
+++ b/bench/hash_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
+func BenchmarkHashInt_MapHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = hashIntMapHash(i)
+	}
+}
+
+func BenchmarkHashInt_MapHasher(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = hashIntMapHasher(i)
+	}
+}
+
 func BenchmarkHashInt_FNV1A(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = hashIntFNV1A(i)
@@ -43,6 +55,18 @@ func BenchmarkHashInt_XXH3HASH(b *testing.B) {
 }
 
 var testString = "test123 dlfksdlföls sdfsdlskdg sgksgjdgs gdkfggk"
+
+func BenchmarkHashString_MapHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = hashStringMapHash(testString)
+	}
+}
+
+func BenchmarkHashString_MapHasher(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = hashStringMapHasher(testString)
+	}
+}
 
 func BenchmarkHashString_FNV1A(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
The standard "hash/maphash" is slowest in town for small types (e.g. `int`).

"github.com/dolthub/maphash" is very fast, but it's a hack that can break with future versions of Go. It is only outperformed by `AESENC` hashing, which is not portable (can only be done for x86 32/64bit and ARM64).
