### PR TITLE
Improve eviction, also for expired items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -62,6 +62,10 @@ type Cache[K comparable, V any] interface {
 	// Purge purges all data (key and value) from the LRU.
 	Purge()
 
+	// PurgeExpired purges all expired items from the LRU.
+	// If the eviction function has been set, it is called for each expired item.
+	PurgeExpired()
+
 	// Metrics returns the metrics of the cache.
 	Metrics() Metrics
 

--- a/cache.go
+++ b/cache.go
@@ -39,31 +39,42 @@ type Cache[K comparable, V any] interface {
 	// Returns true, true if key was updated and eviction occurred.
 	Add(key K, value V) (evicted bool)
 
-	// Get retrieves an element from map under given key.
+	// Get returns the value associated with the key, setting it as the most
+	// recently used item.
+	// If the found cache item is already expired, the evict function is called
+	// and the return value indicates that the key was not found.
 	Get(key K) (V, bool)
 
-	// Peek retrieves an element from map under given key without updating the
-	// "recently used"-ness of that key.
+	// Peek looks up a key's value from the cache, without changing its recent-ness.
+	// If the found entry is already expired, the evict function is called.
 	Peek(key K) (V, bool)
 
 	// Contains checks for the existence of a key, without changing its recent-ness.
+	// If the found entry is already expired, the evict function is called.
 	Contains(key K) bool
 
-	// Remove removes an element from the map.
+	// Remove removes the key from the cache.
 	// The return value indicates whether the key existed or not.
+	// The evict function is called for the removed entry.
 	Remove(key K) bool
 
 	// RemoveOldest removes the oldest entry from the cache.
+	// Key, value and an indicator of whether the entry has been removed is returned.
+	// The evict function is called for the removed entry.
 	RemoveOldest() (key K, value V, removed bool)
 
 	// Keys returns a slice of the keys in the cache, from oldest to newest.
+	// Expired entries are not included.
+	// The evict function is called for each expired item.
 	Keys() []K
 
 	// Purge purges all data (key and value) from the LRU.
+	// The evict function is called for each expired item.
+	// The LRU metrics are reset.
 	Purge()
 
 	// PurgeExpired purges all expired items from the LRU.
-	// If the eviction function has been set, it is called for each expired item.
+	// The evict function is called for each expired item.
 	PurgeExpired()
 
 	// Metrics returns the metrics of the cache.

--- a/lru_test.go
+++ b/lru_test.go
@@ -205,7 +205,7 @@ func testCacheAddWithExpire(t *testing.T, cache Cache[uint64, uint64]) {
 	FatalIf(t, ok, "Expected expiration did not happen")
 
 	// check for element specific lifetime
-	cache.Purge()
+	cache.Purge() // should be a no-op
 	cache.SetLifetime(0)
 	cache.AddWithLifetime(1, 2, 100*time.Millisecond)
 	_, ok = cache.Get(1)

--- a/lru_test.go
+++ b/lru_test.go
@@ -203,9 +203,20 @@ func testCacheAddWithExpire(t *testing.T, cache Cache[uint64, uint64]) {
 	time.Sleep(100 * time.Millisecond)
 	_, ok = cache.Get(3)
 	FatalIf(t, ok, "Expected expiration did not happen")
+	FatalIf(t, cache.Len() != 0, "Cache not empty")
+
+	cache.Add(1, 2)
+	cache.Purge()
+	FatalIf(t, cache.Len() != 0, "Cache not empty")
+
+	cache.AddWithLifetime(1, 2, 100*time.Millisecond)
+	cache.PurgeExpired() // should be a no-op
+	FatalIf(t, cache.Len() != 1, "Expected PurgeExpired to be a no-op")
+	time.Sleep(101 * time.Millisecond)
+	cache.PurgeExpired()
+	FatalIf(t, cache.Len() != 0, "Cache not empty")
 
 	// check for element specific lifetime
-	cache.Purge() // should be a no-op
 	cache.SetLifetime(0)
 	cache.AddWithLifetime(1, 2, 100*time.Millisecond)
 	_, ok = cache.Get(1)

--- a/shardedlru.go
+++ b/shardedlru.go
@@ -236,6 +236,16 @@ func (lru *ShardedLRU[K, V]) Purge() {
 	}
 }
 
+// PurgeExpired purges all expired items from the LRU.
+// If the eviction function has been set, it is called for each expired item.
+func (lru *ShardedLRU[K, V]) PurgeExpired() {
+	for shard := range lru.lrus {
+		lru.mus[shard].Lock()
+		lru.lrus[shard].PurgeExpired()
+		lru.mus[shard].Unlock()
+	}
+}
+
 // Metrics returns the metrics of the cache.
 func (lru *ShardedLRU[K, V]) Metrics() Metrics {
 	metrics := Metrics{}

--- a/shardedlru.go
+++ b/shardedlru.go
@@ -168,9 +168,9 @@ func (lru *ShardedLRU[K, V]) Peek(key K) (value V, ok bool) {
 	hash := lru.hash(key)
 	shard := (hash >> 16) & lru.mask
 
-	lru.mus[shard].RLock()
+	lru.mus[shard].Lock()
 	value, ok = lru.lrus[shard].peek(hash, key)
-	lru.mus[shard].RUnlock()
+	lru.mus[shard].Unlock()
 
 	return
 }
@@ -180,9 +180,9 @@ func (lru *ShardedLRU[K, V]) Contains(key K) (ok bool) {
 	hash := lru.hash(key)
 	shard := (hash >> 16) & lru.mask
 
-	lru.mus[shard].RLock()
+	lru.mus[shard].Lock()
 	ok = lru.lrus[shard].contains(hash, key)
-	lru.mus[shard].RUnlock()
+	lru.mus[shard].Unlock()
 
 	return
 }

--- a/shardedlru_test.go
+++ b/shardedlru_test.go
@@ -29,7 +29,7 @@ func TestShardedRaceCondition(t *testing.T) {
 		}()
 	}
 
-	call(func() { lru.SetLifetime(0) })
+	call(func() { lru.SetLifetime(1) })
 	call(func() { lru.SetOnEvict(nil) })
 	call(func() { _ = lru.Len() })
 	call(func() { _ = lru.AddWithLifetime(1, 1, 0) })
@@ -41,6 +41,7 @@ func TestShardedRaceCondition(t *testing.T) {
 	call(func() { _, _, _ = lru.RemoveOldest() })
 	call(func() { _ = lru.Keys() })
 	call(func() { lru.Purge() })
+	call(func() { lru.PurgeExpired() })
 	call(func() { lru.Metrics() })
 	call(func() { _ = lru.ResetMetrics() })
 	call(func() { lru.dump() })

--- a/syncedlru.go
+++ b/syncedlru.go
@@ -76,8 +76,10 @@ func (lru *SyncedLRU[K, V]) Add(key K, value V) (evicted bool) {
 	return
 }
 
-// Get looks up a key's value from the cache, setting it as the most
+// Get returns the value associated with the key, setting it as the most
 // recently used item.
+// If the found cache item is already expired, the evict function is called
+// and the return value indicates that the key was not found.
 func (lru *SyncedLRU[K, V]) Get(key K) (value V, ok bool) {
 	hash := lru.lru.hash(key)
 
@@ -89,6 +91,7 @@ func (lru *SyncedLRU[K, V]) Get(key K) (value V, ok bool) {
 }
 
 // Peek looks up a key's value from the cache, without changing its recent-ness.
+// If the found entry is already expired, the evict function is called.
 func (lru *SyncedLRU[K, V]) Peek(key K) (value V, ok bool) {
 	hash := lru.lru.hash(key)
 
@@ -100,6 +103,7 @@ func (lru *SyncedLRU[K, V]) Peek(key K) (value V, ok bool) {
 }
 
 // Contains checks for the existence of a key, without changing its recent-ness.
+// If the found entry is already expired, the evict function is called.
 func (lru *SyncedLRU[K, V]) Contains(key K) (ok bool) {
 	hash := lru.lru.hash(key)
 
@@ -125,7 +129,7 @@ func (lru *SyncedLRU[K, V]) Remove(key K) (removed bool) {
 
 // RemoveOldest removes the oldest entry from the cache.
 // Key, value and an indicator of whether the entry has been removed is returned.
-// The evict function is being called if the key existed.
+// The evict function is called for the removed entry.
 func (lru *SyncedLRU[K, V]) RemoveOldest() (key K, value V, removed bool) {
 	lru.mu.Lock()
 	key, value, removed = lru.lru.RemoveOldest()
@@ -135,6 +139,8 @@ func (lru *SyncedLRU[K, V]) RemoveOldest() (key K, value V, removed bool) {
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
+// Expired entries are not included.
+// The evict function is called for each expired item.
 func (lru *SyncedLRU[K, V]) Keys() (keys []K) {
 	lru.mu.RLock()
 	keys = lru.lru.Keys()
@@ -144,6 +150,8 @@ func (lru *SyncedLRU[K, V]) Keys() (keys []K) {
 }
 
 // Purge purges all data (key and value) from the LRU.
+// The evict function is called for each expired item.
+// The LRU metrics are reset.
 func (lru *SyncedLRU[K, V]) Purge() {
 	lru.mu.Lock()
 	lru.lru.Purge()
@@ -151,7 +159,7 @@ func (lru *SyncedLRU[K, V]) Purge() {
 }
 
 // PurgeExpired purges all expired items from the LRU.
-// If the eviction function has been set, it is called for each expired item.
+// The evict function is called for each expired item.
 func (lru *SyncedLRU[K, V]) PurgeExpired() {
 	lru.mu.Lock()
 	lru.lru.PurgeExpired()

--- a/syncedlru.go
+++ b/syncedlru.go
@@ -150,6 +150,14 @@ func (lru *SyncedLRU[K, V]) Purge() {
 	lru.mu.Unlock()
 }
 
+// PurgeExpired purges all expired items from the LRU.
+// If the eviction function has been set, it is called for each expired item.
+func (lru *SyncedLRU[K, V]) PurgeExpired() {
+	lru.mu.Lock()
+	lru.lru.PurgeExpired()
+	lru.mu.Unlock()
+}
+
 // Metrics returns the metrics of the cache.
 func (lru *SyncedLRU[K, V]) Metrics() Metrics {
 	lru.mu.Lock()

--- a/syncedlru_test.go
+++ b/syncedlru_test.go
@@ -26,7 +26,7 @@ func TestSyncedRaceCondition(t *testing.T) {
 		}()
 	}
 
-	call(func() { lru.SetLifetime(0) })
+	call(func() { lru.SetLifetime(1) })
 	call(func() { lru.SetOnEvict(nil) })
 	call(func() { _ = lru.Len() })
 	call(func() { _ = lru.AddWithLifetime(1, 1, 0) })
@@ -38,6 +38,7 @@ func TestSyncedRaceCondition(t *testing.T) {
 	call(func() { _, _, _ = lru.RemoveOldest() })
 	call(func() { _ = lru.Keys() })
 	call(func() { lru.Purge() })
+	call(func() { lru.PurgeExpired() })
 	call(func() { lru.Metrics() })
 	call(func() { _ = lru.ResetMetrics() })
 	call(func() { lru.dump() })


### PR DESCRIPTION
- Purge() calls the evict callback for every item
- Get(), Peek() and Contains() call the evict callback if the found item is expired
- Added new function PurgeExpired()
- Keys() purges expired items first, then creates list of (non-expired) keys

Downside: Peek() and Contains() need to be protected by a write lock, which can have performance drawbacks in highly concurrent situations (also true for many benchmarks).

Fixes #43
Fixes #47