### PR TITLE
Remove toolchain directive from bench/go.mod

### DIFF
--- a/bench/go.mod
+++ b/bench/go.mod
@@ -2,8 +2,6 @@ module github.com/elastic/go-freelru/bench
 
 go 1.21
 
-toolchain go1.23.4
-
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
No need to have this directive. It only triggers dependabot and thus creates noise.

Closes #74