### PR TITLE
CI: Run benchmarks with Go stable

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: true
       max-parallel: 2
       matrix:
-        go: ["1.22"]
+        go: ["stable"]
     steps:
       - name: Set up Go ${{matrix.go}}
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5


### PR DESCRIPTION
Using Go stable for benchmarks is the most interesting setup.
This also reduces manual maintenance of Go versions in CI workflows.