### PR TITLE
Add cache resize support

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -98,4 +98,8 @@ type Cache[K comparable, V any] interface {
 
 	// ResetMetrics resets the metrics of the cache and returns the previous state.
 	ResetMetrics() Metrics
+
+	// Resize changes the cache capacity in place.
+	// If the new capacity is smaller than the current length, oldest entries are evicted.
+	Resize(capacity uint32) (evicted uint32, err error)
 }

--- a/lru.go
+++ b/lru.go
@@ -541,6 +541,15 @@ func (lru *LRU[K, V]) removeAt(pos uint32) {
 	lru.clearKeyAndValue(lru.len)
 }
 
+func (lru *LRU[K, V]) evictAt(pos uint32) {
+	lru.evict(pos)
+	lru.move(pos, lru.len)
+	lru.metrics.Evictions++
+
+	// remove stale data to avoid memory leaks
+	lru.clearKeyAndValue(lru.len)
+}
+
 // RemoveOldest removes the oldest entry from the cache.
 // Key, value and an indicator of whether the entry has been removed is returned.
 // The evict function is called for the removed entry.
@@ -634,6 +643,25 @@ func (lru *LRU[K, V]) ResetMetrics() Metrics {
 	metrics := lru.metrics
 	lru.metrics = Metrics{}
 	return metrics
+}
+
+// Resize changes the cache capacity in place.
+// If the new capacity is smaller than the current length, oldest entries are evicted.
+func (lru *LRU[K, V]) Resize(capacity uint32) (evicted uint32, err error) {
+	if capacity == 0 {
+		return 0, errors.New("capacity must be positive")
+	}
+	if capacity > lru.size {
+		return 0, fmt.Errorf("capacity (%d) is larger than size (%d)", capacity, lru.size)
+	}
+
+	lru.cap = capacity
+	for lru.len > lru.cap {
+		pos := lru.elements[lru.head].next
+		lru.evictAt(pos)
+		evicted++
+	}
+	return evicted, nil
 }
 
 // dump is just used for debugging.

--- a/lru_test.go
+++ b/lru_test.go
@@ -99,6 +99,61 @@ func TestSyncedLRU(t *testing.T) {
 	testCache(t, CAP, makeSyncedLRU(t, CAP, &evictCounter), &evictCounter)
 }
 
+func TestLRUResizeShrinksByEvictingOldest(t *testing.T) {
+	cache, err := NewWithSize[uint64, uint64](4, 8, hashUint64)
+	FatalIf(t, err != nil, "Failed to create LRU: %v", err)
+
+	evictedKeys := []uint64{}
+	cache.SetOnEvict(func(k uint64, _ uint64) {
+		evictedKeys = append(evictedKeys, k)
+	})
+
+	cache.Add(1, 2)
+	cache.Add(2, 3)
+	cache.Add(3, 4)
+	cache.Add(4, 5)
+	_, ok := cache.Get(2)
+	FatalIf(t, !ok, "Failed to get key")
+	cache.ResetMetrics()
+
+	evicted, err := cache.Resize(2)
+	FatalIf(t, err != nil, "Failed to resize LRU: %v", err)
+	FatalIf(t, evicted != 2, "Unexpected number of evictions: %d", evicted)
+	FatalIf(t, cache.Len() != 2, "Unexpected number of entries: %d", cache.Len())
+	FatalIf(t, !reflect.DeepEqual(cache.Keys(), []uint64{4, 2}), "Unexpected keys: %v", cache.Keys())
+	FatalIf(t, !reflect.DeepEqual(evictedKeys, []uint64{1, 3}), "Unexpected evictions: %v", evictedKeys)
+	FatalIf(t, cache.Metrics().Evictions != 2, "Unexpected eviction metrics: %d",
+		cache.Metrics().Evictions)
+}
+
+func TestLRUResizeCanGrowWithinSize(t *testing.T) {
+	cache, err := NewWithSize[uint64, uint64](2, 4, hashUint64)
+	FatalIf(t, err != nil, "Failed to create LRU: %v", err)
+
+	evicted, err := cache.Resize(4)
+	FatalIf(t, err != nil, "Failed to resize LRU: %v", err)
+	FatalIf(t, evicted != 0, "Unexpected number of evictions: %d", evicted)
+
+	for i := uint64(0); i < 4; i++ {
+		cache.Add(i, i+1)
+	}
+	FatalIf(t, cache.Len() != 4, "Unexpected number of entries: %d", cache.Len())
+}
+
+func TestLRUResizeRejectsInvalidCapacityWithoutMutation(t *testing.T) {
+	cache, err := NewWithSize[uint64, uint64](2, 4, hashUint64)
+	FatalIf(t, err != nil, "Failed to create LRU: %v", err)
+
+	cache.Add(1, 2)
+	cache.Add(2, 3)
+
+	_, err = cache.Resize(0)
+	FatalIf(t, err == nil, "Expected resize to reject zero capacity")
+	_, err = cache.Resize(5)
+	FatalIf(t, err == nil, "Expected resize to reject capacity larger than size")
+	FatalIf(t, !reflect.DeepEqual(cache.Keys(), []uint64{1, 2}), "Unexpected keys: %v", cache.Keys())
+}
+
 func testCache(t *testing.T, cAP uint64, cache Cache[uint64, uint64], evictCounter *uint64) {
 	for i := uint64(0); i < cAP*2; i++ {
 		cache.Add(i, i+1)

--- a/shardedlru.go
+++ b/shardedlru.go
@@ -281,7 +281,7 @@ func (lru *ShardedLRU[K, V]) randomShard() int {
 // Expired entries are not included.
 // The evict function is called for each expired item.
 func (lru *ShardedLRU[K, V]) Keys() []K {
-	keys := make([]K, 0, lru.shards*lru.lrus[0].cap)
+	keys := make([]K, 0, lru.Len())
 	for shard := range lru.lrus {
 		lru.mus[shard].Lock()
 		keys = append(keys, lru.lrus[shard].Keys()...)
@@ -295,7 +295,7 @@ func (lru *ShardedLRU[K, V]) Keys() []K {
 // Expired entries are not included.
 // The evict function is called for each expired item.
 func (lru *ShardedLRU[K, V]) Values() []V {
-	values := make([]V, 0, lru.shards*lru.lrus[0].cap)
+	values := make([]V, 0, lru.Len())
 	for shard := range lru.lrus {
 		lru.mus[shard].Lock()
 		values = append(values, lru.lrus[shard].Values()...)
@@ -354,6 +354,49 @@ func (lru *ShardedLRU[K, V]) ResetMetrics() Metrics {
 	}
 
 	return metrics
+}
+
+// Resize changes the cache capacity in place.
+// The requested capacity is distributed across shards. If a shard needs to shrink,
+// it evicts its oldest entries until it fits the new per-shard capacity.
+func (lru *ShardedLRU[K, V]) Resize(capacity uint32) (evicted uint32, err error) {
+	if capacity == 0 {
+		return 0, errors.New("capacity must be positive")
+	}
+	if capacity < lru.shards {
+		return 0, fmt.Errorf("capacity (%d) is smaller than shard count (%d)", capacity, lru.shards)
+	}
+
+	for shard := range lru.lrus {
+		lru.mus[shard].Lock()
+	}
+	defer func() {
+		for shard := len(lru.lrus) - 1; shard >= 0; shard-- {
+			lru.mus[shard].Unlock()
+		}
+	}()
+
+	capacities := make([]uint32, lru.shards)
+	for shard := range lru.lrus {
+		shardCapacity := capacity / lru.shards
+		if uint32(shard) < capacity%lru.shards {
+			shardCapacity++
+		}
+		if shardCapacity > lru.lrus[shard].size {
+			return 0, fmt.Errorf("shard capacity (%d) is larger than shard size (%d)",
+				shardCapacity, lru.lrus[shard].size)
+		}
+		capacities[shard] = shardCapacity
+	}
+
+	for shard := range lru.lrus {
+		shardEvicted, resizeErr := lru.lrus[shard].Resize(capacities[shard])
+		if resizeErr != nil {
+			return evicted, resizeErr
+		}
+		evicted += shardEvicted
+	}
+	return evicted, nil
 }
 
 func addMetrics(dst *Metrics, src Metrics) {

--- a/shardedlru_test.go
+++ b/shardedlru_test.go
@@ -45,6 +45,7 @@ func TestShardedRaceCondition(t *testing.T) {
 	call(func() { lru.PurgeExpired() })
 	call(func() { lru.Metrics() })
 	call(func() { _ = lru.ResetMetrics() })
+	call(func() { _, _ = lru.Resize(CAP) })
 	call(func() { lru.dump() })
 	call(func() { lru.PrintStats() })
 
@@ -54,6 +55,40 @@ func TestShardedRaceCondition(t *testing.T) {
 func TestShardedLRUMetrics(t *testing.T) {
 	cache, _ := NewSharded[uint64, uint64](1, hashUint64)
 	testMetrics(t, cache)
+}
+
+func TestShardedLRUResize(t *testing.T) {
+	cache, err := NewShardedWithSize[uint64, uint64](2, 4, 32, func(v uint64) uint32 {
+		return uint32(v)<<16 | uint32(v)
+	})
+	FatalIf(t, err != nil, "Failed to create ShardedLRU: %v", err)
+
+	evictCounter := uint64(0)
+	cache.SetOnEvict(func(uint64, uint64) {
+		evictCounter++
+	})
+
+	for i := uint64(0); i < 8; i++ {
+		cache.Add(i, i)
+	}
+	cache.ResetMetrics()
+	evictCounter = 0
+
+	evicted, err := cache.Resize(2)
+	FatalIf(t, err != nil, "Failed to resize ShardedLRU: %v", err)
+	FatalIf(t, evicted == 0, "Expected resize to evict entries")
+	FatalIf(t, evictCounter != uint64(evicted), "Unexpected number of callbacks: %d", evictCounter)
+	FatalIf(t, cache.Len() > 2, "Unexpected number of entries: %d", cache.Len())
+	FatalIf(t, cache.Metrics().Evictions != uint64(evicted), "Unexpected eviction metrics: %d",
+		cache.Metrics().Evictions)
+}
+
+func TestShardedLRUResizeRejectsCapacityBelowShardCount(t *testing.T) {
+	cache, err := NewShardedWithSize[uint64, uint64](2, 4, 32, hashUint64)
+	FatalIf(t, err != nil, "Failed to create ShardedLRU: %v", err)
+
+	_, err = cache.Resize(1)
+	FatalIf(t, err == nil, "Expected resize to reject capacity smaller than shard count")
 }
 
 func TestStressWithLifetime(t *testing.T) {

--- a/syncedlru.go
+++ b/syncedlru.go
@@ -225,6 +225,15 @@ func (lru *SyncedLRU[K, V]) ResetMetrics() Metrics {
 	return metrics
 }
 
+// Resize changes the cache capacity in place.
+// If the new capacity is smaller than the current length, oldest entries are evicted.
+func (lru *SyncedLRU[K, V]) Resize(capacity uint32) (evicted uint32, err error) {
+	lru.mu.Lock()
+	evicted, err = lru.lru.Resize(capacity)
+	lru.mu.Unlock()
+	return
+}
+
 // dump is just used for debugging.
 func (lru *SyncedLRU[K, V]) dump() {
 	lru.mu.RLock()

--- a/syncedlru_test.go
+++ b/syncedlru_test.go
@@ -2,6 +2,7 @@
 package freelru
 
 import (
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -42,6 +43,7 @@ func TestSyncedRaceCondition(t *testing.T) {
 	call(func() { lru.PurgeExpired() })
 	call(func() { lru.Metrics() })
 	call(func() { _ = lru.ResetMetrics() })
+	call(func() { _, _ = lru.Resize(CAP) })
 	call(func() { lru.dump() })
 	call(func() { lru.PrintStats() })
 
@@ -51,6 +53,20 @@ func TestSyncedRaceCondition(t *testing.T) {
 func TestSyncedLRU_Metrics(t *testing.T) {
 	cache, _ := NewSynced[uint64, uint64](1, hashUint64)
 	testMetrics(t, cache)
+}
+
+func TestSyncedLRU_Resize(t *testing.T) {
+	cache, err := NewSyncedWithSize[uint64, uint64](3, 4, hashUint64)
+	FatalIf(t, err != nil, "Failed to create SyncedLRU: %v", err)
+
+	cache.Add(1, 2)
+	cache.Add(2, 3)
+	cache.Add(3, 4)
+
+	evicted, err := cache.Resize(1)
+	FatalIf(t, err != nil, "Failed to resize SyncedLRU: %v", err)
+	FatalIf(t, evicted != 2, "Unexpected number of evictions: %d", evicted)
+	FatalIf(t, !reflect.DeepEqual(cache.Keys(), []uint64{3}), "Unexpected keys: %v", cache.Keys())
 }
 
 func TestSyncedLRU_RemoveOldest(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a `Resize` method to the LRU cache implementations.

The method changes capacity in place. When the new capacity is lower than the current length, the cache evicts oldest entries until it fits. Growing is allowed up to the backing `size` that was allocated when the cache was created.

This is implemented for:

- `LRU`
- `SyncedLRU`
- `ShardedLRU`
- the shared `Cache` interface

For `ShardedLRU`, the requested capacity is distributed across shards. This keeps the existing sharded behavior: eviction is per shard rather than globally exact LRU.

## Notes

- Resize-driven removals increment `Metrics.Evictions`.
- `onEvict` is called for each entry evicted by resize.
- Existing Add/Get/Peek hot paths are unchanged.
- `ShardedLRU.Keys` and `ShardedLRU.Values` now preallocate from `Len()` instead of reading `lru.lrus[0].cap` directly. With resize, shard capacity can change while those methods are running; `Len()` already reads shard state under the shard locks, and the result is only used as a slice capacity hint.

## Testing

```text
go test -count=1 ./...
go test -race -count=1 ./...
```

Benchmark comparison against upstream `v0.16.0`:

```text
go test -run ^$ -bench . -benchmem -benchtime=500ms -count=5 -cpu=1
```

Median results across 5 samples:

| Benchmark | upstream ns/op | branch ns/op | delta | allocs/op |
|---|---:|---:|---:|---:|
| LRUAddEvict | 10.95 | 10.93 | -0.2% | 0 |
| LRUGetHit | 5.049 | 5.014 | -0.7% | 0 |
| LRUPeekHit | 3.859 | 3.834 | -0.6% | 0 |
| ShardedAddEvict | 23.41 | 23.37 | -0.2% | 0 |
| ShardedGetHit | 21.88 | 21.56 | -1.5% | 0 |
